### PR TITLE
Fix expo start errors and warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connectfe",
-  "main": "expo-router/entry",
+  "main": "expo/AppEntry",
   "version": "1.0.0",
   "scripts": {
     "start": "expo start",

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -105,8 +105,12 @@ function SidebarProvider({
       }
     };
 
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
+    if (typeof window !== "undefined") {
+      window.addEventListener("keydown", handleKeyDown);
+      return () => window.removeEventListener("keydown", handleKeyDown);
+    }
+
+    return () => {};
   }, [toggleSidebar]);
 
   // We add a state so that we can do data-state="expanded" or "collapsed".

--- a/src/hooks/useOfflineSync.ts
+++ b/src/hooks/useOfflineSync.ts
@@ -5,14 +5,26 @@ export function useOfflineSync() {
   const syncingRef = useRef(false);
 
   useEffect(() => {
+    const canUseWindow = typeof window !== 'undefined' && typeof window.addEventListener === 'function';
+    const canCheckNavigator = typeof navigator !== 'undefined' && 'onLine' in navigator;
+
     const handler = () => {
-      if (navigator.onLine) {
+      if (!canCheckNavigator || (navigator as any).onLine) {
         flushQueue();
       }
     };
-    window.addEventListener('online', handler);
+
+    if (canUseWindow) {
+      window.addEventListener('online', handler);
+    }
+
     flushQueue();
-    return () => window.removeEventListener('online', handler);
+
+    return () => {
+      if (canUseWindow) {
+        window.removeEventListener('online', handler);
+      }
+    };
   }, []);
 
   const flushQueue = async () => {

--- a/src/screens/user/QRCheckinScreen.tsx
+++ b/src/screens/user/QRCheckinScreen.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
-import { BarCodeScanner } from 'expo-barcode-scanner';
+import { View, Text, StyleSheet, TouchableOpacity, Platform } from 'react-native';
 import { useTheme } from '../../contexts/ThemeContext';
 import { apiService } from '../../services/api';
 
@@ -8,12 +7,30 @@ export function QRCheckinScreen({ navigation }: any) {
   const { colors } = useTheme();
   const [hasPermission, setHasPermission] = useState<boolean | null>(null);
   const [scanned, setScanned] = useState(false);
+  const [Scanner, setScanner] = useState<any>(null);
 
   React.useEffect(() => {
+    let mounted = true;
     (async () => {
-      const { status } = await BarCodeScanner.requestPermissionsAsync();
-      setHasPermission(status === 'granted');
+      if (Platform.OS === 'ios' || Platform.OS === 'android') {
+        try {
+          const mod = await import('expo-barcode-scanner');
+          const BarCodeScanner = (mod as any).BarCodeScanner;
+          if (mounted) {
+            setScanner(() => BarCodeScanner);
+            const { status } = await BarCodeScanner.requestPermissionsAsync();
+            setHasPermission(status === 'granted');
+          }
+        } catch (e) {
+          if (mounted) setHasPermission(false);
+        }
+      } else {
+        if (mounted) setHasPermission(false);
+      }
     })();
+    return () => {
+      mounted = false;
+    };
   }, []);
 
   const handleBarCodeScanned = async ({ data }: any) => {
@@ -40,10 +57,12 @@ export function QRCheckinScreen({ navigation }: any) {
 
   return (
     <View style={{ flex: 1 }}>
-      <BarCodeScanner
-        onBarCodeScanned={scanned ? undefined : handleBarCodeScanned}
-        style={StyleSheet.absoluteFillObject}
-      />
+      {Scanner ? (
+        <Scanner
+          onBarCodeScanned={scanned ? undefined : handleBarCodeScanned}
+          style={StyleSheet.absoluteFillObject}
+        />
+      ) : null}
       {scanned && (
         <TouchableOpacity onPress={() => setScanned(false)} style={{ position: 'absolute', bottom: 40, alignSelf: 'center', backgroundColor: colors.primary, paddingHorizontal: 16, paddingVertical: 10, borderRadius: 8 }}>
           <Text style={{ color: colors.primaryForeground, fontWeight: '600' }}>Escanear novamente</Text>

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -1,4 +1,5 @@
 import * as Notifications from 'expo-notifications';
+import Constants from 'expo-constants';
 import * as Device from 'expo-device';
 import { Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -17,6 +18,12 @@ class NotificationService {
   private expoPushToken: string | null = null;
 
   async initialize() {
+    // Skip push token in web and Expo Go (SDK 53 removed push in Expo Go)
+    if (Platform.OS === 'web' || Constants?.appOwnership === 'expo') {
+      console.log('Pulando registro de push em Web/Expo Go');
+      return null;
+    }
+
     if (Device.isDevice) {
       const { status: existingStatus } = await Notifications.getPermissionsAsync();
       let finalStatus = existingStatus;


### PR DESCRIPTION
Resolve `expo start` errors by updating the entry point, guarding web-specific APIs, lazy-loading native modules, and conditionally skipping push notification registration.

The `expo start` command was failing with several errors, including "Cannot find native module 'ExpoBarCodeScanner'", "window.addEventListener is not a function", "missing required default export" for routes, and `expo-notifications` warnings for Expo Go SDK 53. This PR addresses these by disabling `expo-router` for the entry point, guarding browser-specific APIs (`window.addEventListener`, `navigator.onLine`), dynamically importing `expo-barcode-scanner` only on native platforms, and skipping push notification registration on web and Expo Go.

---
<a href="https://cursor.com/background-agent?bcId=bc-acb16c78-237d-4016-8759-a3e1e77ed85d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-acb16c78-237d-4016-8759-a3e1e77ed85d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

